### PR TITLE
Fix a race condition in Task.race

### DIFF
--- a/packages/ajaxian/yarn.lock
+++ b/packages/ajaxian/yarn.lock
@@ -2735,10 +2735,10 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@~1.17.0:
   dependencies:
     path-parse "^1.0.6"
 
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
+resulty@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
+  integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
 
 resumer@~0.0.0:
   version "0.0.0"
@@ -3186,12 +3186,12 @@ tape@^4.6.3:
     string.prototype.trim "~1.2.1"
     through "~2.3.8"
 
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
+taskarian@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.2.0.tgz#ecb3fd874e7ebb9bd073814d6680e88fb31e38e0"
+  integrity sha512-unOpUkjHC2iHG9ZDsxYkwDqKORDFAPHWWlGzASiDB7rXEzNdHDx+EU1PqMscjBkXjdFnYCVrD4m9/hDOBjFrEg==
   dependencies:
-    resulty "^4.0.0"
+    resulty "^5.0.0"
 
 through2@2.0.1:
   version "2.0.1"

--- a/packages/ajaxios/yarn.lock
+++ b/packages/ajaxios/yarn.lock
@@ -739,9 +739,9 @@ custom-event@~1.0.0:
   integrity sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
 
 date-fns@^2.16.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
-  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 date-format@^2.0.0, date-format@^2.1.0:
   version "2.1.0"
@@ -1556,14 +1556,14 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonous@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-6.1.0.tgz#ced81b0ca07d90e27be85e529ba581fa2f5bd417"
-  integrity sha512-AOR1ciUWGVy8TVBqBa15yhREJfvz6TotJf261RADRzGk8XtigvZpRmfHXqcG2BcDj99HOQgOl48JNypNuqgHaA==
+jsonous@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/jsonous/-/jsonous-7.1.0.tgz#2bae7e9cacd9f89e35e3e80bd573c57a5b1a6803"
+  integrity sha512-Wu82ADyHAVpyDzPDHa/ihrNE1M+e36iPaQm195QPiAjxrjNOpQ5FHaqSC9gXiZeUiAHFp69sfV0BpSmzWPGyfA==
   dependencies:
     date-fns "^2.16.1"
     maybeasy "^3.0.0"
-    resulty "^4.0.0"
+    resulty "^5.0.0"
     weakset "^1.0.0"
 
 karma-chrome-launcher@^3.0:
@@ -2183,10 +2183,10 @@ resolve@~1.17.0:
   dependencies:
     path-parse "^1.0.6"
 
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
+resulty@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
+  integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
 
 resumer@~0.0.0:
   version "0.0.0"
@@ -2510,12 +2510,12 @@ tape@^4.6.3:
     string.prototype.trim "~1.2.1"
     through "~2.3.8"
 
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
+taskarian@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.2.0.tgz#ecb3fd874e7ebb9bd073814d6680e88fb31e38e0"
+  integrity sha512-unOpUkjHC2iHG9ZDsxYkwDqKORDFAPHWWlGzASiDB7rXEzNdHDx+EU1PqMscjBkXjdFnYCVrD4m9/hDOBjFrEg==
   dependencies:
-    resulty "^4.0.0"
+    resulty "^5.0.0"
 
 through2@^2.0.0:
   version "2.0.5"

--- a/packages/gaia/yarn.lock
+++ b/packages/gaia/yarn.lock
@@ -235,10 +235,10 @@ resolve@^1.1.6:
   dependencies:
     path-parse "^1.0.6"
 
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
+resulty@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
+  integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
 
 shelljs@^0.8.4:
   version "0.8.4"
@@ -270,12 +270,12 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-taskarian@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.0.0.tgz#c82484b7b135629f07c18c689f99142c466894dd"
-  integrity sha512-C0cDkBYMpG6jXDUhdTxYL0ckXhRUVZddukexD+rrXamYIZy8k3DJ0vmNa49CrXiyLrcIDMoz1yJd6jFd2Lifcg==
+taskarian@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/taskarian/-/taskarian-4.2.0.tgz#ecb3fd874e7ebb9bd073814d6680e88fb31e38e0"
+  integrity sha512-unOpUkjHC2iHG9ZDsxYkwDqKORDFAPHWWlGzASiDB7rXEzNdHDx+EU1PqMscjBkXjdFnYCVrD4m9/hDOBjFrEg==
   dependencies:
-    resulty "^4.0.0"
+    resulty "^5.0.0"
 
 touch@^3.1.0:
   version "3.1.0"

--- a/packages/jsonous/yarn.lock
+++ b/packages/jsonous/yarn.lock
@@ -665,10 +665,10 @@ resolve@^1.1.6, resolve@^1.17.0:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
+resulty@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
+  integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
 
 resumer@^0.0.0:
   version "0.0.0"

--- a/packages/nonempty-list/yarn.lock
+++ b/packages/nonempty-list/yarn.lock
@@ -546,10 +546,10 @@ resolve@~1.13.1:
   dependencies:
     path-parse "^1.0.6"
 
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
+resulty@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resulty/-/resulty-5.0.0.tgz#962fec061caaade8d600d39d88db370c4f4a9a9a"
+  integrity sha512-K4E8JWqVqjCimjfdM/QyQWLs8xwdhJGVsVy2T6hvU9ihTEaEL72/eI/8wtVP7ddM+DKD2dNnNxLwthoX0RZrow==
 
 resumer@~0.0.0:
   version "0.0.0"

--- a/packages/taskarian/package.json
+++ b/packages/taskarian/package.json
@@ -18,7 +18,8 @@
     "yarn": "yarn"
   },
   "dependencies": {
-    "resulty": "^5.0.0"
+    "@kofno/piper": "^4.1.0",
+    "maybeasy": "^3.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.2.29",

--- a/packages/taskarian/src/Task.ts
+++ b/packages/taskarian/src/Task.ts
@@ -1,10 +1,10 @@
+import { always, noop } from '@kofno/piper';
+import { fromEmpty } from "maybeasy";
+
 export type Reject<E> = (err: E) => void;
 export type Resolve<T> = (t: T) => void;
 export type Cancel = () => void;
 export type Computation<E, T> = (reject: Reject<E>, resolve: Resolve<T>) => Cancel;
-
-// tslint:disable-next-line:no-empty
-const noop = (): void => {};
 
 class Task<E, T> {
   /**
@@ -79,32 +79,80 @@ class Task<E, T> {
    *
    *     new Task([longFetchTask, timeoutTask])
    */
-  public static race<T, E>(ts: Array<Task<E, T>>): Task<E, T> {
-    if (ts.length === 0) {
-      return new Task((reject, resolve) => noop);
-    }
+  public static race<E, T>(tasks: ReadonlyArray<Task<E, T>>): Task<E, T> {
+    type Status = 'waiting' | 'resolved' | 'rejected';
 
-    return new Task((reject, resolve) => {
-      let resolved = false;
-      const cancels: Array<() => void> = [];
+    return fromEmpty(tasks).cata({
+      Nothing: () => new Task<E, T>(always(noop)),
+      Just: () =>
+        new Task<E, T>((reject, resolve) => {
+          let status: Status = 'waiting';
+          const cancels: Array<Cancel> = [];
 
-      const resolveIf = (result: T) => {
-        if (!resolved) {
-          resolved = true;
-          resolve(result);
-          cancels.forEach((fn) => fn());
-        }
-      };
-      // tslint:disable-next-line:prefer-for-of
-      for (let i = 0; i < ts.length; i++) {
-        cancels.push(ts[i].fork(reject, resolveIf));
-      }
+          const cancelAll = (): void => {
+            let cancel: Cancel | undefined;
+            while ((cancel = cancels.shift())) cancel();
+          };
 
-      return () => {
-        cancels.forEach((fn) => fn());
-      };
+          const cancelAllIfNotStillWaiting = (): void => {
+            switch (status) {
+              case 'waiting':
+                break;
+              case 'rejected':
+              case 'resolved':
+                cancelAll();
+                break;
+            }
+          };
+
+          const resolveAndCancelAll = (t: T): void => {
+            switch (status) {
+              case 'waiting':
+                status = 'resolved';
+                resolve(t);
+                cancelAll();
+                break;
+              case 'resolved':
+              case 'rejected':
+                break;
+            }
+          };
+          const rejectAndCancelAll = (e: E): void => {
+            switch (status) {
+              case 'waiting':
+                status = 'rejected';
+                reject(e);
+                cancelAll();
+                break;
+              case 'resolved':
+              case 'rejected':
+                break;
+            }
+          };
+
+          const forkTaskIfStillWaiting = (task: Task<E, T>): void => {
+            switch (status) {
+              case 'waiting': {
+                const cancel = task.fork(rejectAndCancelAll, resolveAndCancelAll);
+                cancels.push(cancel);
+                break;
+              }
+              case 'rejected':
+              case 'resolved':
+                break;
+            }
+          };
+
+          for (let i = 0; i < tasks.length; i++) {
+            forkTaskIfStillWaiting(tasks[i]);
+          }
+
+          cancelAllIfNotStillWaiting();
+
+          return () => cancelAll();
+        }),
     });
-  }
+  };
 
   /**
    * `loop` returns a higher-order task forks the "inner" task until the inner task

--- a/packages/taskarian/yarn.lock
+++ b/packages/taskarian/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@kofno/piper@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@kofno/piper/-/piper-4.1.0.tgz#7c932f1f4ca18cd319f39c69210e7a935e04a2af"
+  integrity sha512-q4f4e4LlWaEOp5H2xqJikcmPUO9CWJ+PwnRQNlTgXwBOf7r4LyUlXEureGI9Tgz4eYF4RRYb00G1LACRIsF5bg==
+
 "@types/node@*":
   version "14.0.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
@@ -348,6 +353,11 @@ marked@^2.0.3:
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.3.tgz#3551c4958c4da36897bda2a16812ef1399c8d6b0"
   integrity sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==
 
+maybeasy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/maybeasy/-/maybeasy-3.0.0.tgz#732c244da190c742de99aa682e6f86a66152bbcc"
+  integrity sha512-hMjmt0Kmfp2PdG9knKi6eUdp4513hkDib99EKqMK5tu1mn+t4Hih/pbJ4g5Kf3+f+c6GV6tBinZqtTtcnubm/g==
+
 minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -500,11 +510,6 @@ resolve@^1.1.6, resolve@~1.17.0:
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
-
-resulty@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resulty/-/resulty-4.0.0.tgz#fbd6470fde712a88b7c983394c7486da290ea6e2"
-  integrity sha512-toajg6lqdp9tmV0ohsTxWiwoaWJd2WiuH7vOx+BJtj1Bs9+XoGa+0Zu8yRNV02gS5DphnrdnRG4Xjr7vl+eP8g==
 
 resumer@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Fixes a race condition bug in `Task.race`:

The array of tasks that it receives is forked in order. If one of those tasks resolves before the rest of the tasks in the array are forked, then the remaining tasks are not added to the cancellation array by the time that that array is iterated to cancel those tasks. The effect is that those remaining tasks continue in the background since now the code has moved on. 

In my case, the entire code path finished and then hung at the end waiting for a timeout task to complete before Node could exit. My issue was seen with the reject branch which had no cancellation logic in the original implementation, which seemed like an oversight. But this bug also existed in the resolve branch.

With this rewrite, tasks are only forked if one hasn't already completed, both completion branches employ the cancellation of all tasks, and there is a new check immediately after forking all tasks which will cancel them all if any one of them already completed.